### PR TITLE
Move increase in test coverage to step 2.5

### DIFF
--- a/steps/2-simple_function.md
+++ b/steps/2-simple_function.md
@@ -29,9 +29,8 @@ If you get stuck, [take a peek at the solution](https://github.com/keeppythonwei
   (catpy)user@host:~/catinabox$ python setup.py test
   ```
   
-  When the tests run successfully, you should see an increase in coverage!
-
-5. (Optional) Bonus: Try to write some tests for ```is_cat_leap_year```. Are
+5. (Optional) Bonus: Try to write some tests for ```is_cat_leap_year```. (When 
+   these tests run successfully, you should see an increase in coverage!) Are
    you sufficiently convinced that this function works now? Why or why not?
 
    We'd love to have a discussion about this with you if you get this far. Every


### PR DESCRIPTION
Filling in the body of the tests (step 2.4) won't change the test coverage because they're already stubbed out with `assert True`. Adding tests for `is_cat_leap_year` will increase the test coverage, though.

Thanks for the workshop!
